### PR TITLE
Fix missing wViewDir variable and undeclared/wrongly declared vars

### DIFF
--- a/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
@@ -285,9 +285,9 @@
         
         void PBRLightingUtils_readPBRSurface(inout PBRSurface surface){
 
-            surface.bakedLightContribution = vec3(0);
-            surface.directLightContribution = vec3(0);
-            surface.envLightContribution = vec3(0);
+            surface.bakedLightContribution = vec3(0.0);
+            surface.directLightContribution = vec3(0.0);
+            surface.envLightContribution = vec3(0.0);
 
             #ifdef ENABLE_PBRLightingUtils_getWorldTangent
                 vec3 tan = normalize(wTangent.xyz); 
@@ -297,7 +297,7 @@
 
             
             #if (defined(PARALLAXMAP) || (defined(NORMALMAP_PARALLAX) && defined(NORMALMAP)))
-                vec3 vViewDir =  wViewDir * surface.tbnMat;  
+                vec3 vViewDir =  surface.viewDir * surface.tbnMat;  
                 #ifdef STEEP_PARALLAX
                     #ifdef NORMALMAP_PARALLAX
                         //parallax map is stored in the alpha channel of the normal map         
@@ -429,7 +429,7 @@
                 #endif
                 surface.emission = emissive.rgb * pow(emissive.a, m_EmissivePower) * m_EmissiveIntensity;
             #else 
-                surface.emission = vec3(0);
+                surface.emission = vec3(0.0);
             #endif
 
             PBRLightingUtils_readSunLightExposureParams(surface);
@@ -573,8 +573,8 @@
 
 
             #if NB_PROBES > 0
-                float probeNdfSum=0;
-                float invProbeNdfSum=0;    
+                float probeNdfSum = 0.0;
+                float invProbeNdfSum = 0.0;    
 
                 #for i=1..4 ( #if NB_PROBES >= $i $0 #endif )
                     vec3 probeColor$i;
@@ -607,7 +607,7 @@
                 #endfor
 
                 #if NB_PROBES > 1
-                    float probeWeightSum=0;
+                    float probeWeightSum= 0.0;
                     #for i=1..4 ( #if NB_PROBES >= $i $0 #endif )
                         float probeWeight$i = ((1.0 - (probeNdf$i / probeNdfSum)) / (NB_PROBES - 1)) *  ( probeInvNdf$i / invProbeNdfSum);
                         probeWeightSum += probeWeight$i;    

--- a/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
@@ -236,7 +236,7 @@
             Math_lengthAndNormalize(light.vector,dist,L);
 
             float invRange=light.invRadius; // position.w
-            const float light_threshold=0.01;
+            const float light_threshold = 0.01;
 
             #ifdef SRGB
                 light.fallOff = (1.0 - invRange * dist) / (1.0 + invRange * dist * dist); // lightDir.w
@@ -607,7 +607,7 @@
                 #endfor
 
                 #if NB_PROBES > 1
-                    float probeWeightSum= 0.0;
+                    float probeWeightSum = 0.0;
                     #for i=1..4 ( #if NB_PROBES >= $i $0 #endif )
                         float probeWeight$i = ((1.0 - (probeNdf$i / probeNdfSum)) / (NB_PROBES - 1)) *  ( probeInvNdf$i / invProbeNdfSum);
                         probeWeightSum += probeWeight$i;    

--- a/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
@@ -272,11 +272,26 @@
 
     PBRSurface PBRLightingUtils_createPBRSurface(in vec3 wViewDir){
 
-        PBRSurface surface;
+        PBRSurface surface; //creates a new PBRSurface
+        
         surface.position = wPosition;
         surface.viewDir = wViewDir;
         surface.geometryNormal = normalize(wNormal);
 
+        //set default values
+        surface.hasTangents = false;
+        surface.hasBasicLightMap = false;        
+        surface.albedo = vec3(1.0);
+        surface.normal = surface.geometryNormal;
+        surface.emission = vec3(0.0);        
+        surface.ao = vec3(1.0);
+        surface.lightMapColor = vec3(0.0);
+        surface.alpha = 1.0;
+        surface.roughness = 1.0;
+        surface.metallic = 0.0;
+        surface.alpha = 1.0;
+        surface.exposure = 1.0;        
+        
         return surface;
     }
 

--- a/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
+++ b/jme3-core/src/main/resources/Common/ShaderLib/module/pbrlighting/PBRLightingUtils.glsllib
@@ -650,6 +650,9 @@
         else if(debugValuesMode == 7){
             outputColorForLayer.rgb = vec3(surface.alpha);          
         } 
+        else if(debugValuesMode == 8){
+            outputColorForLayer.rgb = vec3(surface.geometryNormal);          
+        }
 
         if(debugValuesMode >= 0){
             gl_FragColor.a = 1.0;


### PR DESCRIPTION
The wViewDir varying was changed to be stored in the surface.viewDir value, so the references to that variable needed to be updated to match this.

I also changed some floats to be in decimal format.